### PR TITLE
Add realistic branches to step matching regular expression.

### DIFF
--- a/lib/step-jumper.coffee
+++ b/lib/step-jumper.coffee
@@ -13,6 +13,6 @@ module.exports =
     checkMatch: ({filePath, matches}) ->
       for match in matches
         console.log("Searching in #{filePath}")
-        if regexMatches = match.matchText.match(/^\w+\(\/(.*)\/\)/)
+        if regexMatches = match.matchText.match(/^\w+[\s+\(]['"\/](.*)['"\/]i?[\s+\)]/)
           if @restOfLine.match(new RegExp(regexMatches[1]))
             return [filePath, match.range[0][0]]


### PR DESCRIPTION
I encountered the issue in #1 as well, and wrote a fix. This regular expression was painful incomplete.

In order to get it to work in my ruby project, I needed to:
- Match steps that don't use parens, which are optional in ruby: `Given /^I am a user$?`
- Match steps that use exact matches rather than regular expressions: `Given 'I am a user'` `Given "I am a user"`
- Match steps that use case-insensitive regex matching: `When /We aren't wearing pants/i` (useful when nesting steps, such as in: `When It as after midnight and we aren't wearing pants`
