### PR TITLE
Add support for quoted, rather than regex based jump-to

### DIFF
--- a/lib/step-jumper.coffee
+++ b/lib/step-jumper.coffee
@@ -13,11 +13,20 @@ module.exports =
     checkMatch: ({filePath, matches}) ->
       for match in matches
         console.log("Searching in #{filePath}")
-        regex = match.matchText.match(/\/([^/]*)/)
+        regex = @extractRegex(match.matchText)
+        continue unless regex
         try
-          regex = new RegExp(regex[1])
+          regex = new RegExp(regex)
         catch e
           console.log(e)
           continue
         if @restOfLine.match(regex)
           return [filePath, match.range[0][0]]
+
+    extractRegex: (matchText) ->
+      regexMatch = matchText.match(/\/([^/]*)/)
+      if regexMatch
+        return regexMatch[1]
+      patternMatch = matchText.match(/("|')(.*)\1/)
+      if patternMatch
+        return patternMatch[2].replace(/(\\?["'])\$\w+\1/g,"$1(.*)$1").replace(/\$\w+/, "(\\d+)")

--- a/spec/jump-to-spec.coffee
+++ b/spec/jump-to-spec.coffee
@@ -3,10 +3,15 @@ StepJumper = require "../lib/step-jumper"
 describe "jumping", ->
   beforeEach ->
     @stepJumper = new StepJumper("  Given I have a cheese")
+    @interpolatedStepJumper = new StepJumper("  Given I have 2 \"blue\" 'cheeses'")
 
   describe "stepTypeRegex", ->
     it "should match right step types", ->
       expect("Given(/I have a cheese/)".match(@stepJumper.stepTypeRegex())).toBeTruthy()
+    it "should match quoted step types", ->
+      expect("Given('I have a cheese')".match(@stepJumper.stepTypeRegex())).toBeTruthy()
+    it "should match interpolated step types", ->
+      expect("Given('I have $digits \"$color\" '$objectType'')".match(@stepJumper.stepTypeRegex())).toBeTruthy()
     it "should not match wrong step types", ->
       expect("With(/I have a cheese/)".match(@stepJumper.stepTypeRegex())).toBeFalsy()
 
@@ -59,3 +64,14 @@ describe "jumping", ->
         matches: [@match]
     it "should return undefined", ->
       expect(@stepJumper.checkMatch(@scanMatch)).toEqual(undefined)
+
+  describe "checkMatch quoted", ->
+    beforeEach ->
+      @match =
+        matchText: "Given('I have $digits \"$color\" '$objectType'')"
+        range: [[20,0], [25, 0]]
+      @scanMatch =
+        filePath: "path/to/file"
+        matches: [@match]
+    it "should return file and line", ->
+      expect(@interpolatedStepJumper.checkMatch(@scanMatch)).toEqual(["path/to/file", 20])


### PR DESCRIPTION
This patch adds support for jumping to quoted steps, like:

```
Given("I have $digits '$colour' \"$objectType\"")
```