### PR TITLE
Support Scenario Outline

### DIFF
--- a/lib/cucumber-step.coffee
+++ b/lib/cucumber-step.coffee
@@ -15,7 +15,10 @@ module.exports =
     return unless stepJumper.firstWord
     options =
       paths: ["**/features/step_definitions/**/*.rb",
-              "**/features/step_definitions/**/*.js"]
+              "**/features/step_definitions/**/*.js",
+              "**/step_definitions/**/*.rb",
+              "**/step_definitions/**/*.js"
+             ]
     atom.workspace.scan stepJumper.stepTypeRegex(), options, (match) ->
       if foundMatch = stepJumper.checkMatch(match)
         [file, line] = foundMatch

--- a/lib/cucumber-step.coffee
+++ b/lib/cucumber-step.coffee
@@ -10,7 +10,31 @@ module.exports =
       'cucumber-step:jump-to-step': => @jump()
 
   jump: ->
-    currentLine = atom.workspace.getActiveTextEditor().getLastCursor().getCurrentBufferLine()
+    currentEditor = atom.workspace.getActiveTextEditor()
+    currentLine = currentEditor.getLastCursor().getCurrentBufferLine()
+    isOutline = currentLine.match(/<[\w.-]+>/)
+    currentRow = currentEditor.getLastCursor().getBufferRow()
+    bufferedLines = currentEditor.getBuffer().getLines()
+    while isOutline
+      currentRow += 1
+      nextLineText = bufferedLines[currentRow]
+      if nextLineText.match(/examples:/i)
+        exampleHeadText = bufferedLines[currentRow + 1].split "|"
+        exampleValueText = bufferedLines[currentRow + 2].split "|"
+        Column = 0
+        for key in exampleHeadText
+          key = key.replace /^\s+|\s+$/g, ""
+          value = exampleValueText[Column].replace /^\s+|\s+$/g, ""
+          if not key
+            Column += 1
+            continue
+          #console.log("key: #{key} - #{value}")
+          regex = new RegExp("<#{key}>", "g");
+          currentLine = currentLine.replace regex, value
+          Column += 1
+        console.log("After replace outlines: #{currentLine}")
+        break
+
     stepJumper = new StepJumper(currentLine)
     return unless stepJumper.firstWord
     options =

--- a/lib/step-jumper.coffee
+++ b/lib/step-jumper.coffee
@@ -5,7 +5,7 @@ module.exports =
       matchData = @line.match(/^\s*(\w+)\s+(.*)/)
       if matchData
         @firstWord = matchData[1]
-        @restOfLine = matchData[2]
+        @restOfLine = matchData[2].replace /^\s+|\s+$/g, ""
 
     stepTypeRegex: ->
       new RegExp "(Given|When|Then|And)\(.*\)"


### PR DESCRIPTION
Scenario outline need to replace with the example.
````````````
Scenario Outline: test scenario outline
  Given I have 1 <COLOR> apple and 1 <MATERIAL> cube

  Examples:
  |COLOR |MATERIAL    |
  |red  |iron   |
````````````
2 other minor fixes:
1) Added "**/step_definitions/**" as the search path because I used to add features as workspace
2) Remove line end white spaces, cucumber will trim as well.