### PR TITLE
improved handling of regex matching

### DIFF
--- a/lib/step-jumper.coffee
+++ b/lib/step-jumper.coffee
@@ -24,7 +24,7 @@ module.exports =
           return [filePath, match.range[0][0]]
 
     extractRegex: (matchText) ->
-      regexMatch = matchText.match(/\([^/]*\/(.*)\/[^,]*,.*\)/)
+      regexMatch = matchText.match(/\([^/]*\/(.*)\/.*\)/)
       if regexMatch
         return regexMatch[1]
       patternMatch = matchText.match(/("|')(.*)\1/)

--- a/lib/step-jumper.coffee
+++ b/lib/step-jumper.coffee
@@ -24,7 +24,7 @@ module.exports =
           return [filePath, match.range[0][0]]
 
     extractRegex: (matchText) ->
-      regexMatch = matchText.match(/\/([^/]*)/)
+      regexMatch = matchText.match(/\/(.*)\//)
       if regexMatch
         return regexMatch[1]
       patternMatch = matchText.match(/("|')(.*)\1/)

--- a/lib/step-jumper.coffee
+++ b/lib/step-jumper.coffee
@@ -24,7 +24,7 @@ module.exports =
           return [filePath, match.range[0][0]]
 
     extractRegex: (matchText) ->
-      regexMatch = matchText.match(/\/(.*)\//)
+      regexMatch = matchText.match(/^\/(.*)\/$/)
       if regexMatch
         return regexMatch[1]
       patternMatch = matchText.match(/("|')(.*)\1/)

--- a/lib/step-jumper.coffee
+++ b/lib/step-jumper.coffee
@@ -24,7 +24,7 @@ module.exports =
           return [filePath, match.range[0][0]]
 
     extractRegex: (matchText) ->
-      regexMatch = matchText.match(/^\/(.*)\/$/)
+      regexMatch = matchText.match(/\([^/]*\/(.*)\/[^,]*,.*\)/)
       if regexMatch
         return regexMatch[1]
       patternMatch = matchText.match(/("|')(.*)\1/)

--- a/spec/jump-to-spec.coffee
+++ b/spec/jump-to-spec.coffee
@@ -23,9 +23,12 @@ describe "jumping", ->
       @match2 =
         matchText: "Given(/^I have a cheese$/)"
         range: [[20, 0], [25, 0]]
+      @match3 =
+        matchText: "Given(/^an escaped \/ is in this match$/)"
+        range: [[10, 0], [15, 0]]
       @scanMatch =
         filePath: "path/to/file"
-        matches: [@match1, @match2]
+        matches: [@match1, @match2, @match3]
     it "should return file and line", ->
       expect(@stepJumper.checkMatch(@scanMatch)).toEqual(["path/to/file", 20])
 


### PR DESCRIPTION
In the current implementation of extractRegex, the matching stops when it finds a '/' character. If there is an escaped '\/' in the regex string, the matching will stop too soon and fail because of an invalid regex. This updates the matching regex to greedily match a everything between '/' and '/'. I added a test case to jump-to-spec.coffee, but I don't know how to run it. I manually verified my fix by copying step-jumper.coffee to ~/.atom/packages/cucumber-step/lib, rerunning atom with 'atom -d', opening a feature file, clicking on this line:
`Given user goes to precinct <precinct> / pollstation <pollstation> management page for app 1`
and pressing ctrl-alt-j and verified that the correct step definition was opened.
I also clicked on this line and verified that ctrl-alt-j jumps to the right step definition:
`And user restarts apache on poll station`
also verified this line jumps correctly
 `And user drops and reseeds the database on poll station using resources/e3-seed.sql`
