### PR TITLE
Only trigger the keymap in feature files

### DIFF
--- a/keymaps/cucumber-step.cson
+++ b/keymaps/cucumber-step.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'atom-text-editor':
+'atom-text-editor[data-grammar=source.feature]':
   'ctrl-alt-j': 'cucumber-step:jump-to-step'


### PR DESCRIPTION
As per description : reduce the scope of the keymap to feature files only (e.g. plugins like language-gherkin) so the binding can be re-used for other modules to mean "jump to the definition of this thing".