### PR TITLE
Make search paths configurable

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,0 +1,10 @@
+module.exports =
+  searchPaths:
+    description: "For looking up Cucumber step definition files (comma-separated list of glob patters)"
+    type: "array"
+    default: [
+      "*.js",
+      "*.rb",
+    ]
+    items:
+      type: "string"

--- a/lib/cucumber-step.coffee
+++ b/lib/cucumber-step.coffee
@@ -1,7 +1,9 @@
 StepJumper = require './step-jumper'
+config = require './config'
 {CompositeDisposable} = require 'atom'
 
 module.exports =
+  config: config
   subscriptions: null
 
   activate: ->
@@ -14,8 +16,7 @@ module.exports =
     stepJumper = new StepJumper(currentLine)
     return unless stepJumper.firstWord
     options =
-      paths: ["**/features/step_definitions/**/*.rb",
-              "**/features/step_definitions/**/*.js"]
+      paths: atom.config.get('cucumber-step.searchPaths')
     atom.workspace.scan stepJumper.stepTypeRegex(), options, (match) ->
       if foundMatch = stepJumper.checkMatch(match)
         [file, line] = foundMatch


### PR DESCRIPTION
This is alternative for PR #18, which I ended up writing before noticing that there already existed a PR for such a feature.

Main differences from PR #18:

- Defaulted to searching through all *.js and *.rb files, which should work for most users.  It might not be fastest, in which case a more specific path can be configured.
- Configuration lives in a separate file.
- Different name for the setting. PR #18 uses `step_path`, while this PR uses `searchPaths` which I think better follows JS convention of using camelCase and is also in plural, hinting that it's an array.
- Hard-coded `'cucumber-step.searchPaths'` v/s `pkg.name + '.step_path'` in PR #18.

Perhaps there is something to include from both PR-s.

I think the important question is how to best name this, and what would be the good default values so it would work well out of the box for most users.