### PR TITLE
Extend path step definitions

### DIFF
--- a/lib/cucumber-step.coffee
+++ b/lib/cucumber-step.coffee
@@ -15,7 +15,8 @@ module.exports =
     return unless stepJumper.firstWord
     options =
       paths: ["**/features/step_definitions/**/*.rb",
-              "**/features/step_definitions/**/*.js"]
+              "**/features/step_definitions/**/*.js",
+              "**/features/**/*.rb"]
     atom.workspace.scan stepJumper.stepTypeRegex(), options, (match) ->
       if foundMatch = stepJumper.checkMatch(match)
         [file, line] = foundMatch


### PR DESCRIPTION
Right now the code only look for step definitions under this folder `features/step_definitions`. However there's another practice like putting step definitions and feature file under the same folder then this plugin will not work.

```ruby
features
  - Feature_A
     - my_feature_a.feature
     - my_feature_steps.rb
```

This PR would allow to jump into cucumber step with above structure.